### PR TITLE
Add modular document parser toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
 # Eduparser
+
+EduParser converts educational documents such as PDF, DOCX, HTML or plain
+text files into clean JSONL chunks that can be fed to machine learning
+pipelines. It offers a modular architecture:
+
+1. **pdf_extractor** – reads text from various formats.
+2. **content_cleaner** – normalises and cleans raw text.
+3. **chunk_generator** – splits text into roughly 300 token chunks.
+4. **metadata_injector** – attaches metadata like grade, course and topic.
+5. **jsonl_exporter** – writes the processed data to JSONL files.
+6. **faiss_indexer** *(optional)* – builds a FAISS vector index from JSONL
+   records.
+
+## Installation
+
+Install the core dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+For FAISS indexing support, also install:
+
+```bash
+pip install -r requirements.txt -r requirements-faiss.txt
+```
+To enable the OpenAI ``tiktoken`` based tokenizer used by ``--tokenizer openai``
+install ``tiktoken`` as well:
+
+```bash
+pip install tiktoken
+```
+
+## Command line usage
+
+```bash
+python -m eduparser.cli book.pdf \
+  --sınıf 4 --ders "Fen Bilgisi" --konu "Maddenin Halleri" \
+  --out output.jsonl --tokenizer openai --split_headings \
+  --id_strategy uuid --index output.faiss \
+  --model_name sentence-transformers/all-MiniLM-L6-v2
+```
+
+This command extracts the text from `book.pdf`, cleans and chunks it,
+attaches the provided metadata and finally writes `output.jsonl`. Because an
+`--index` path was provided, a FAISS index is also built using the specified
+embedding model.
+
+## Streamlit GUI
+
+For a graphical interface launch the Streamlit app:
+
+```bash
+streamlit run app.py
+```
+
+The GUI allows uploading PDF, DOCX, HTML or TXT files, entering grade, course
+and topic information, adjusting the chunk size and optionally creating a
+FAISS index. After processing, download links for the generated JSONL and
+index files are presented along with a preview of the first records and basic
+statistics.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,106 @@
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import streamlit as st
+
+from eduparser.pipeline import EduParserConfig, run_pipeline
+from eduparser.pdf_extractor import extract_text
+from eduparser.content_cleaner import clean_text
+from eduparser.faiss_indexer import DEFAULT_MODEL
+
+
+st.set_page_config(page_title="EduParser")
+st.title("EduParser GUI")
+
+uploaded = st.file_uploader(
+    "Belge yükle", type=["pdf", "docx", "txt", "html", "htm"]
+)
+grade = st.selectbox("Sınıf", [str(i) for i in range(1, 9)])
+course = st.text_input("Ders adı")
+topic = st.text_input("Konu adı")
+max_tokens = st.slider("Token sayısı", 50, 1000, 300, step=50)
+
+use_uuid = st.checkbox("UUID tabanlı ID kullan")
+
+build_index = st.checkbox("FAISS index oluşturulsun mu?")
+model_name: Optional[str] = None
+if build_index:
+    model_name = st.text_input("Model adı", value=DEFAULT_MODEL)
+
+convert = st.button("Dönüştür")
+
+
+@st.cache_data(show_spinner=False)
+def cached_clean_text(file_bytes: bytes, filename: str) -> str:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=Path(filename).suffix) as tmp:
+        tmp.write(file_bytes)
+        tmp_path = Path(tmp.name)
+    try:
+        text = extract_text(tmp_path)
+        return clean_text(text)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+if convert:
+    if not uploaded or not course or not topic:
+        st.error("Lütfen dosya seçip tüm alanları doldurun.")
+    else:
+        progress = st.progress(0)
+        status = st.empty()
+
+        def update(step: int, total: int) -> None:
+            progress.progress(step / total)
+
+        cleaned = cached_clean_text(uploaded.getvalue(), uploaded.name)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "output.jsonl"
+            index_path = Path(tmpdir) / "output.faiss" if build_index else None
+
+            metadata = {"sınıf": grade, "ders": course, "konu": topic}
+            config = EduParserConfig(
+                source_path=uploaded.name,
+                out_path=jsonl_path,
+                metadata=metadata,
+                max_tokens=max_tokens,
+                id_strategy="uuid" if use_uuid else "simple",
+                index_path=index_path,
+                model_name=model_name or DEFAULT_MODEL,
+            )
+
+            records = run_pipeline(
+                config, text=cleaned, progress_cb=update
+            )
+
+            progress.empty()
+            status.text("İşlem tamamlandı.")
+
+            st.success(f"{len(records)} kayıt üretildi.")
+
+            avg_tokens = sum(len(r["content"].split()) for r in records) / len(records)
+            st.write(
+                f"Toplam chunk sayısı: {len(records)}, Ortalama uzunluk: {avg_tokens:.1f} kelime"
+            )
+
+            st.subheader("Önizleme")
+            st.table(records[:3])
+
+            json_bytes = jsonl_path.read_bytes()
+
+            with st.expander("İndirme Linkleri"):
+                st.download_button("JSONL indir", json_bytes, "output.jsonl", "application/json")
+
+                if build_index and index_path and index_path.exists():
+                    faiss_bytes = index_path.read_bytes()
+                    st.download_button(
+                        "FAISS indir", faiss_bytes, "output.faiss", "application/octet-stream",
+                    )
+                    ids_bytes = (index_path.with_suffix(index_path.suffix + ".ids")).read_bytes()
+                    st.download_button(
+                        "ID dosyasını indir",
+                        ids_bytes,
+                        "output.faiss.ids",
+                        "application/json",
+                    )

--- a/eduparser/chunk_generator.py
+++ b/eduparser/chunk_generator.py
@@ -1,0 +1,64 @@
+"""Split cleaned text into manageable pieces."""
+from __future__ import annotations
+
+import re
+from typing import List
+
+try:  # Optional tiktoken import for accurate token counting
+    import tiktoken
+except Exception:  # pragma: no cover - optional dependency
+    tiktoken = None
+
+
+def _count_tokens(text: str, tokenizer: str) -> int:
+    if tokenizer == "simple":
+        return len(text.split())
+    if tokenizer == "openai":
+        if tiktoken is None:
+            raise RuntimeError("tiktoken is required for tokenizer='openai'")
+        enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    raise ValueError(f"Unknown tokenizer: {tokenizer}")
+
+
+def generate_chunks(
+    text: str,
+    max_tokens: int = 300,
+    *,
+    tokenizer: str = "simple",
+    respect_headings: bool = False,
+    heading_pattern: str = r"^(#+\s+|Bölüm\b)",
+) -> List[str]:
+    """Yield chunks of approximately *max_tokens* tokens.
+
+    Splits the text on paragraph boundaries (double newlines) and groups
+    paragraphs until the token count would exceed ``max_tokens``. Token
+    counting can use a simple whitespace method or ``tiktoken`` when
+    ``tokenizer='openai'``. If ``respect_headings`` is ``True``, paragraphs
+    matching ``heading_pattern`` will start a new chunk.
+    """
+    paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
+    heading_re = re.compile(heading_pattern, re.IGNORECASE)
+    chunks: list[str] = []
+    current: list[str] = []
+    token_count = 0
+
+    for para in paragraphs:
+        if respect_headings and heading_re.match(para) and current:
+            chunks.append("\n\n".join(current))
+            current = []
+            token_count = 0
+
+        tokens = _count_tokens(para, tokenizer)
+        if token_count + tokens > max_tokens and current:
+            chunks.append("\n\n".join(current))
+            current = []
+            token_count = 0
+
+        current.append(para)
+        token_count += tokens
+
+    if current:
+        chunks.append("\n\n".join(current))
+
+    return chunks

--- a/eduparser/cli.py
+++ b/eduparser/cli.py
@@ -1,0 +1,75 @@
+"""Command line interface for the EduParser toolkit."""
+from __future__ import annotations
+
+import argparse
+import logging
+
+from .pipeline import EduParserConfig, run_pipeline
+from .faiss_indexer import DEFAULT_MODEL
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convert educational materials into JSONL chunks")
+    parser.add_argument("source", help="Input document (PDF, DOCX, HTML, TXT)")
+    parser.add_argument("--sınıf", required=True, help="Grade level")
+    parser.add_argument("--ders", required=True, help="Course name")
+    parser.add_argument("--konu", required=True, help="Topic")
+    parser.add_argument("--out", default="output.jsonl", help="Output JSONL file")
+    parser.add_argument("--max_tokens", type=int, default=300, help="Approximate tokens per chunk")
+    parser.add_argument(
+        "--tokenizer",
+        choices=["simple", "openai"],
+        default="simple",
+        help="Token counting method",
+    )
+    parser.add_argument(
+        "--split_headings",
+        action="store_true",
+        help="Start new chunks at heading markers",
+    )
+    parser.add_argument(
+        "--id_strategy",
+        choices=["simple", "uuid"],
+        default="simple",
+        help="Record ID generation method",
+    )
+    parser.add_argument("--index", help="Optional path to build a FAISS index")
+    parser.add_argument(
+        "--model_name",
+        default=DEFAULT_MODEL,
+        help="Embedding model used when building the FAISS index",
+    )
+    return parser
+
+
+def main(args: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger("eduparser")
+
+    parser = build_arg_parser()
+    ns = parser.parse_args(args=args)
+
+    metadata = {"sınıf": ns.sınıf, "ders": ns.ders, "konu": ns.konu}
+    config = EduParserConfig(
+        source_path=ns.source,
+        out_path=ns.out,
+        metadata=metadata,
+        max_tokens=ns.max_tokens,
+        tokenizer=ns.tokenizer,
+        split_headings=ns.split_headings,
+        id_strategy=ns.id_strategy,
+        index_path=ns.index,
+        model_name=ns.model_name,
+    )
+
+    records = run_pipeline(config)
+    logger.info("Wrote %d records to %s", len(records), ns.out)
+
+    if ns.index:
+        logger.info("Built FAISS index at %s", ns.index)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/eduparser/content_cleaner.py
+++ b/eduparser/content_cleaner.py
@@ -1,0 +1,39 @@
+"""Utilities for cleaning extracted text.
+
+The :func:`clean_text` function removes excessive whitespace, line numbers
+and trivial artefacts that commonly appear in OCR or PDF sourced text.
+"""
+from __future__ import annotations
+
+import re
+
+
+_LINE_NUM_RE = re.compile(r"^\s*\d+[\.)]?\s*")
+
+# Preset patterns for common PDF artefacts that should be removed entirely.
+_ARTEFACT_PATTERNS = [
+    re.compile(r"^sayfa\s*\d+", re.IGNORECASE),
+    re.compile(r"\bEBA\b"),
+    re.compile(r"\bMEB\b"),
+]
+
+
+def _strip_line_numbers(lines: list[str]) -> list[str]:
+    return [_LINE_NUM_RE.sub("", ln).strip() for ln in lines]
+
+
+def clean_text(text: str) -> str:
+    """Return a normalised version of *text*.
+
+    The function performs several lightweight cleanups:
+
+    * Remove leading line numbers (e.g. "1. Foo")
+    * Drop common PDF artefacts such as "sayfa" headers or "EBA" markers
+    * Collapse multiple whitespace characters
+    * Drop empty lines
+    """
+    lines = text.splitlines()
+    lines = _strip_line_numbers(lines)
+    filtered = [ln for ln in lines if not any(p.search(ln) for p in _ARTEFACT_PATTERNS)]
+    cleaned = [re.sub(r"\s+", " ", ln).strip() for ln in filtered if ln.strip()]
+    return "\n".join(cleaned)

--- a/eduparser/faiss_indexer.py
+++ b/eduparser/faiss_indexer.py
@@ -1,0 +1,52 @@
+"""Build a FAISS vector index from JSONL records."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+
+# Default embedding model used for indexing.
+DEFAULT_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def build_faiss_index(
+    jsonl_path: str | Path,
+    index_path: str | Path,
+    model_name: str = DEFAULT_MODEL,
+) -> None:
+    """Create a FAISS index from a JSONL file.
+
+    Each line in *jsonl_path* must be a JSON object with at least ``id`` and
+    ``content`` fields. Embeddings are created using a SentenceTransformer
+    model and stored in a simple ``IndexFlatL2`` FAISS index. The index is
+    written to *index_path* and an accompanying ``.ids`` JSON file stores the
+    document ids in order.
+    """
+    try:
+        from sentence_transformers import SentenceTransformer  # type: ignore
+        import faiss  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error informative
+        raise ImportError("sentence-transformers and faiss are required for indexing") from exc
+
+    jsonl_path = Path(jsonl_path)
+    index_path = Path(index_path)
+
+    texts: List[str] = []
+    ids: List[str] = []
+    with jsonl_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            obj = json.loads(line)
+            texts.append(obj["content"])
+            ids.append(obj["id"])
+
+    model = SentenceTransformer(model_name)
+    embeddings = model.encode(texts, show_progress_bar=True, convert_to_numpy=True)
+
+    dim = embeddings.shape[1]
+    index = faiss.IndexFlatL2(dim)
+    index.add(embeddings)
+    faiss.write_index(index, str(index_path))
+
+    with (index_path.with_suffix(index_path.suffix + ".ids")).open("w", encoding="utf-8") as f:
+        json.dump(ids, f, ensure_ascii=False)

--- a/eduparser/jsonl_exporter.py
+++ b/eduparser/jsonl_exporter.py
@@ -1,0 +1,14 @@
+"""Export records to JSON Lines format."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Dict
+
+
+def export_to_jsonl(records: Iterable[Dict], path: str | Path) -> None:
+    """Write *records* to *path* in JSON Lines format."""
+    p = Path(path)
+    with p.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/eduparser/metadata_injector.py
+++ b/eduparser/metadata_injector.py
@@ -1,0 +1,29 @@
+"""Attach metadata to text chunks."""
+from __future__ import annotations
+
+import uuid
+from typing import Dict, Iterable, List
+
+
+def inject_metadata(
+    chunks: Iterable[str], metadata: Dict[str, str], *, id_strategy: str = "simple"
+) -> List[Dict[str, str]]:
+    """Combine *chunks* with *metadata* and assign record IDs.
+
+    ``id_strategy`` controls how ``id`` fields are generated:
+
+    - ``"simple"``: sequential IDs based on the course name.
+    - ``"uuid"``: random UUID4 values.
+    """
+
+    results: list[dict[str, str]] = []
+    for idx, chunk in enumerate(chunks, start=1):
+        if id_strategy == "uuid":
+            rec_id = str(uuid.uuid4())
+        else:
+            rec_id = f"{metadata.get('ders', 'doc')}_{idx}"
+
+        item = {"id": rec_id, "content": chunk}
+        item.update(metadata)
+        results.append(item)
+    return results

--- a/eduparser/pdf_extractor.py
+++ b/eduparser/pdf_extractor.py
@@ -1,0 +1,86 @@
+"""Module for extracting text from various document formats.
+
+Supports PDF, DOCX, HTML and plain text files. For PDF parsing the
+`pdfplumber` library is used. DOCX files are handled via `python-docx`
+while HTML files rely on `BeautifulSoup` from `bs4`.
+
+The main entrypoint is :func:`extract_text` which returns the textual
+content of the given document as a single string.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+
+def _read_txt(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _read_pdf(path: Path) -> str:
+    try:
+        import pdfplumber  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error is informative
+        raise ImportError("pdfplumber is required for PDF extraction") from exc
+
+    text_parts: list[str] = []
+    with pdfplumber.open(path) as pdf:
+        for page in pdf.pages:
+            page_text = page.extract_text() or ""
+            text_parts.append(page_text)
+    return "\n".join(text_parts)
+
+
+def _read_docx(path: Path) -> str:
+    try:
+        import docx  # type: ignore
+    except Exception as exc:
+        raise ImportError("python-docx is required for DOCX extraction") from exc
+
+    document = docx.Document(str(path))
+    paragraphs = [p.text for p in document.paragraphs]
+    return "\n".join(paragraphs)
+
+
+def _read_html(path: Path) -> str:
+    try:
+        from bs4 import BeautifulSoup  # type: ignore
+    except Exception as exc:
+        raise ImportError("beautifulsoup4 is required for HTML extraction") from exc
+
+    html = path.read_text(encoding="utf-8")
+    soup = BeautifulSoup(html, "html.parser")
+    return soup.get_text(separator="\n")
+
+
+_READERS = {
+    ".pdf": _read_pdf,
+    ".txt": _read_txt,
+    ".docx": _read_docx,
+    ".html": _read_html,
+    ".htm": _read_html,
+}
+
+
+def extract_text(path: str | Path) -> str:
+    """Extract text from *path*.
+
+    Parameters
+    ----------
+    path:
+        Path to the document to read.
+
+    Returns
+    -------
+    str
+        All textual content found in the document.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(p)
+
+    reader = _READERS.get(p.suffix.lower())
+    if reader is None:
+        raise ValueError(f"Unsupported file type: {p.suffix}")
+
+    return reader(p)

--- a/eduparser/pipeline.py
+++ b/eduparser/pipeline.py
@@ -1,0 +1,86 @@
+"""High level orchestration for the EduParser toolkit."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, Optional
+
+from .pdf_extractor import extract_text
+from .content_cleaner import clean_text
+from .chunk_generator import generate_chunks
+from .metadata_injector import inject_metadata
+from .jsonl_exporter import export_to_jsonl
+from .faiss_indexer import build_faiss_index, DEFAULT_MODEL
+
+
+@dataclass
+class EduParserConfig:
+    """Configuration for :func:`run_pipeline`."""
+
+    source_path: str | Path
+    out_path: str | Path
+    metadata: Dict[str, str]
+    max_tokens: int = 300
+    tokenizer: str = "simple"
+    split_headings: bool = False
+    id_strategy: str = "simple"
+    index_path: str | Path | None = None
+    model_name: str = DEFAULT_MODEL
+
+
+def run_pipeline(
+    config: EduParserConfig,
+    *,
+    text: Optional[str] = None,
+    extract_fn: Callable[[str | Path], str] = extract_text,
+    clean_fn: Callable[[str], str] = clean_text,
+    progress_cb: Optional[Callable[[int, int], None]] = None,
+) -> Iterable[Dict[str, str]]:
+    """Execute the full extraction pipeline.
+
+    ``text`` may be provided to skip the extraction/cleaning stages. If
+    ``progress_cb`` is supplied it will be called with ``(step, total_steps)``
+    after each stage.
+    """
+
+    total_steps = 5 + (1 if config.index_path else 0)
+    if text is not None:
+        total_steps -= 2
+
+    step = 0
+
+    def update_progress() -> None:
+        nonlocal step
+        step += 1
+        if progress_cb:
+            progress_cb(step, total_steps)
+
+    if text is None:
+        text = extract_fn(config.source_path)
+        update_progress()
+        text = clean_fn(text)
+        update_progress()
+
+    chunks = generate_chunks(
+        text,
+        max_tokens=config.max_tokens,
+        tokenizer=config.tokenizer,
+        respect_headings=config.split_headings,
+    )
+    update_progress()
+
+    records = inject_metadata(
+        chunks, config.metadata, id_strategy=config.id_strategy
+    )
+    update_progress()
+
+    export_to_jsonl(records, config.out_path)
+    update_progress()
+
+    if config.index_path:
+        build_faiss_index(
+            config.out_path, config.index_path, model_name=config.model_name
+        )
+        update_progress()
+
+    return records

--- a/requirements-faiss.txt
+++ b/requirements-faiss.txt
@@ -1,0 +1,2 @@
+sentence-transformers
+faiss-cpu

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Core dependencies
+pdfplumber
+python-docx
+beautifulsoup4
+streamlit
+
+# Optional dependencies for FAISS indexing
+# Install with: pip install -r requirements.txt -r requirements-faiss.txt
+# Optional dependency for OpenAI-style token counting
+# tiktoken


### PR DESCRIPTION
## Summary
- centralize extract/clean/chunk/inject/export steps in a shared pipeline
- generate record IDs via selectable strategies and simplify JSONL export
- update CLI/GUI to use the pipeline, add caching and grouped downloads

## Testing
- `python -m pip install pdfplumber python-docx beautifulsoup4 tiktoken sentence-transformers faiss-cpu streamlit`
- `python -m eduparser.cli sample.txt --sınıf 4 --ders "Fen Bilgisi" --konu "Maddenin Halleri" --out output.jsonl --id_strategy uuid --index output.faiss --model_name sentence-transformers/all-MiniLM-L6-v2`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6891a8a5d04c832dbd3023128118cd72